### PR TITLE
Added option to override host url that is injected

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -175,6 +175,12 @@ exports.swapFile = function (elem, attr, opts) {
         if (!opts.timestamps) {
             suffix = "";
         }
+        if (opts.overrideHost) {
+            var urlSplit = currentValue.split("/");
+            var currentHost = urlSplit[0] + "//" + urlSplit[2] + "/";
+            var newHost = opts.overrideHost + "/";
+            currentValue = currentValue.replace(currentHost,newHost);
+        }
     }
 
     elem[attr] = currentValue + suffix;


### PR DESCRIPTION
This is a small change that looks for an option:

```
overrideHost: "http://10.0.1.3:3002"
```

In this case I am using BrowserSync to host the CSS file. This allows me to inject newly compiled CSS into a remote site I am working on.
